### PR TITLE
兼容系统环境变量OPENAI_API_KEY格式

### DIFF
--- a/openai_forward/settings.py
+++ b/openai_forward/settings.py
@@ -1,4 +1,5 @@
 import itertools
+from json import JSONDecodeError
 import os
 
 import limits
@@ -119,7 +120,12 @@ if CACHE_GENERAL:
 IP_WHITELIST = env2list("IP_WHITELIST", sep=ENV_VAR_SEP)
 IP_BLACKLIST = env2list("IP_BLACKLIST", sep=ENV_VAR_SEP)
 
-OPENAI_API_KEY = env2dict("OPENAI_API_KEY")
+OPENAI_API_KEY = "" #兼容大部分框架的key，和本框架需要的json格式
+try:    
+    OPENAI_API_KEY = env2dict("OPENAI_API_KEY")
+except JSONDecodeError:
+    OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
+    
 FWD_KEY = env2dict("FORWARD_KEY")
 LEVEL_MODELS = {int(key): value for key, value in env2dict("LEVEL_MODELS").items()}
 


### PR DESCRIPTION
大部分框架和服务，对OPENAI_API_KEY环境变量的定义都是直接str格式的key；
但是跟你这个刚好冲突了，启动就报错，都没机会进webui配置。

做了下兼容