### PR TITLE
fix: Handle missing content in chat log messages

### DIFF
--- a/openai_forward/webui/chat.py
+++ b/openai_forward/webui/chat.py
@@ -12,7 +12,7 @@ def render_chat_log_message(msg: Dict, markdown=True):
         with st.chat_message(name="user", avatar='🧑'):
             for msg_item in messages:
                 # https://github.com/streamlit/streamlit/issues/7978
-                render(f"`{msg_item['role']}`: {msg_item['content']}")
+                render(f"`{msg_item['role']}`: {msg_item.get('content', '')}")
             st.write(msg)
     elif msg.get("assistant_role"):
         with st.chat_message(name="assistant", avatar='🤖'):


### PR DESCRIPTION
当功能为function calling时，msg_item不包含content，会导致webui显示内容时出现错误